### PR TITLE
Rename `github_token` to `gh_token` in reusable workflows

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,7 +8,7 @@ on:
         required: false
         default: npm ci
     secrets:
-      github_token: 
+      gh_token: 
         required: true
       npm_token:
         required: true
@@ -42,5 +42,5 @@ jobs:
           # This expects you to have a script called release which does a build for your packages and calls changeset publish
           publish: npm run release
         env:
-          GITHUB_TOKEN: ${{ secrets.github_token }}
+          GITHUB_TOKEN: ${{ secrets.gh_token }}
           NPM_TOKEN: ${{ secrets.npm_token }}

--- a/.github/workflows/release_canary.yml
+++ b/.github/workflows/release_canary.yml
@@ -8,7 +8,7 @@ on:
         required: false
         default: npm ci
     secrets:
-      github_token: 
+      gh_token: 
         required: true
       npm_token:
         required: true

--- a/.github/workflows/release_candidate.yml
+++ b/.github/workflows/release_candidate.yml
@@ -8,7 +8,7 @@ on:
         required: false
         default: npm ci
     secrets:
-      github_token: 
+      gh_token: 
         required: true
       npm_token:
         required: true
@@ -49,7 +49,7 @@ jobs:
           echo "$( jq ".version = \"$(echo $version)-rc.$(git rev-parse --short HEAD)\"" package.json )" > package.json
           yarn publish --tag next
         env:
-          GITHUB_TOKEN: ${{ secrets.github_token }}
+          GITHUB_TOKEN: ${{ secrets.gh_token }}
 
       - name: Output candidate version
         uses: actions/github-script@v4.0.2


### PR DESCRIPTION
## Problem

The `github_token` secret cannot be used in reusable workflows because it would collide with the system reserved name

[![CleanShot 2021-12-14 at 09 27 40](https://user-images.githubusercontent.com/4608155/146049243-fba99568-67c2-426a-bb05-5557a49b992c.png)](https://github.com/primer/css/actions/runs/1578852244)

## Solution

Rename `github_token` to `gh_token` in reusable workflows
