### PR TITLE
Guard reusable workflows against missing secrets

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,9 +14,24 @@ on:
         required: true
 
 jobs:
+  has:
+    name: Check Secrets
+    runs-on: ubuntu-latest
+    steps:
+    - id: secrets
+      env:
+        npm_token: ${{ secrets.npm_token }}
+        gh_token: ${{ secrets.gh_token }}
+      if: ${{ env.npm_token != '' && env.gh_token != '' }}
+      run:
+        echo "::set-output name=secrets::1"
+    outputs:
+      secrets: ${{ steps.secrets.outputs.secrets }}
+
   release:
     name: Release
-
+    needs: has
+    if: ${{ needs.has.outputs.secrets }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository

--- a/.github/workflows/release_canary.yml
+++ b/.github/workflows/release_canary.yml
@@ -14,8 +14,24 @@ on:
         required: true
 
 jobs:
+  has:
+    name: Check Secrets
+    runs-on: ubuntu-latest
+    steps:
+    - id: secrets
+      env:
+        npm_token: ${{ secrets.npm_token }}
+        gh_token: ${{ secrets.gh_token }}
+      if: ${{ env.npm_token != '' && env.gh_token != '' }}
+      run:
+        echo "::set-output name=secrets::1"
+    outputs:
+      secrets: ${{ steps.secrets.outputs.secrets }}
+
   release-canary:
     name: Canary
+    needs: has
+    if: ${{ needs.has.outputs.secrets }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository

--- a/.github/workflows/release_candidate.yml
+++ b/.github/workflows/release_candidate.yml
@@ -14,8 +14,24 @@ on:
         required: true
 
 jobs:
+  has:
+    name: Check Secrets
+    runs-on: ubuntu-latest
+    steps:
+    - id: secrets
+      env:
+        npm_token: ${{ secrets.npm_token }}
+        gh_token: ${{ secrets.gh_token }}
+      if: ${{ env.npm_token != '' && env.gh_token != '' }}
+      run:
+        echo "::set-output name=secrets::1"
+    outputs:
+      secrets: ${{ steps.secrets.outputs.secrets }}
+
   release-candidate:
     name: Candidate
+    needs: has
+    if: ${{ needs.has.outputs.secrets }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository


### PR DESCRIPTION
The current workflow results in lots of build failures on forks. These guards result in a different experience for people when they fork repositories that use these reusable workflows.