### PR TITLE
Release next to consumers

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -73,6 +73,6 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: paper-spa/deploy-pages@main
+        uses: actions/deploy-pages@v1
         with:
           preview: false

--- a/.github/workflows/deploy_preview.yml
+++ b/.github/workflows/deploy_preview.yml
@@ -83,6 +83,6 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: paper-spa/deploy-pages@main
+        uses: actions/deploy-pages@v1
         with:
           preview: true


### PR DESCRIPTION
`next` branch has been tested successfully in [primer/brand](https://github.com/primer/brand/pull/83) and [primer/react](https://github.com/primer/react/pull/2377). Contains updates from https://github.com/primer/.github/pull/6