### PR TITLE
Upgrade changesets/action to 1.4.1 release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ on:
         required: false
         default: Release tracking
     secrets:
-      gh_token: 
+      gh_token:
         required: true
       npm_token:
         required: true
@@ -40,7 +40,10 @@ jobs:
 
       - name: Create release pull request or publish to npm
         id: changesets
-        uses: changesets/action@master
+        # Uses SHA for security hardening
+        # Currently pointing at a commit for the v1.4.1 tag
+        # Please keep this up-to-date if you're changing the SHA below
+        uses: changesets/action@e9cc34b540dd3ad1b030c57fd97269e8f6ad905a
         with:
           title: ${{ inputs.title }}
           # This expects you to have a script called release which does a build for your packages and calls changeset publish


### PR DESCRIPTION
This PR updates our release workflow to use the latest `changesets/action` workflows.

**Before:**
We were pointing at `master` branch, which isn't the base branch of `changesets/action` anymore. It's no longer actively maintained, and has been replaced by `main`. 

Deprecation of `master` occurred on Nov 26, 2021. Continuing to use this branch unfortunately leaves us open to security exploits.

**After:**
We're now pointing at the [latest `1.4.1` release using its SHA](https://github.com/changesets/action/commit/e9cc34b540dd3ad1b030c57fd97269e8f6ad905a) for maximum security hardening. This is immutable and prevents _new_ exploits upstream from propagating down to our caller workflow. Note that we'll need to manually upgrade for newer features or patch updates going forward. 


**Testing..**

1. Merge this
2. Test in Primer Brand or another project which has a caller workflow and a Release Tracking branch open