### PR TITLE
Add a job to call dotcom primer workflow when RC is published

### DIFF
--- a/.github/workflows/release_candidate.yml
+++ b/.github/workflows/release_candidate.yml
@@ -56,7 +56,8 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.gh_token }}
 
       - name: Output candidate version
-        uses: actions/github-script@v4.0.2
+        id: candidate-version
+        uses: actions/github-script@v6
         with:
           script: |
             const package = require(`${process.env.GITHUB_WORKSPACE}/package.json`)
@@ -69,3 +70,13 @@ jobs:
               description: package.version,
               target_url: `https://unpkg.com/${package.name}@${package.version}/`
             })
+
+  rc-at-dotcom:
+      name: Run primer integration workflow at dotcom
+      needs: release-candidate
+      # Using the branch name for ref as the PR is still not merged - TODO: Remove this once we confirm that the workflow is running as expected
+      uses: github/github/.github/workflows/primer-react-nightly.yml@primer-react-nightly
+      # TODO: FInd out how to get the PR number for the release and the sha that is merged into main and trigger the workflow with those inputs 
+      with:
+        merged-pr: 'TODO: Get the SHA that is merged into main and triggers the workflow'
+        release-pr: 'TODO: Get the PR number for the release'

--- a/.github/workflows/release_candidate.yml
+++ b/.github/workflows/release_candidate.yml
@@ -74,8 +74,8 @@ jobs:
   rc-at-dotcom:
       name: Run primer integration workflow at dotcom
       needs: release-candidate
-      # Using the branch name for ref as the PR is still not merged - TODO: Remove this once we confirm that the workflow is running as expected
-      uses: github/github/.github/workflows/primer-react-nightly.yml@primer-react-nightly
+      # Using the branch name for ref as the PR is still WIP - TODO: Remove this once we confirm that the workflow is running as expected
+      uses: github/github/.github/workflows/primer-react-nightly.yml@primer-react-at-RC-time
       # TODO: FInd out how to get the PR number for the release and the sha that is merged into main and trigger the workflow with those inputs 
       with:
         merged-pr: 'TODO: Get the SHA that is merged into main and triggers the workflow'


### PR DESCRIPTION
Related https://github.com/github/primer/issues/1842

Adds a job to [the release_candidate workflow](https://github.com/primer/.github/blob/main/.github/workflows/release_candidate.yml) after publishing new RC package to run [primer workflow at dotcom](https://github.com/github/github/blob/d2468742a1d0e84b29769f34147d589502da0680/.github/workflows/primer-react-nightly.yml)

TODO:

- [ ] Find a way to get the release PR to pass onto the dotcom workflow
- [ ] Find a way to get the PR that is merged into main and trigger the release candidate workflow. 


