### PR TITLE
Optional Node Version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,10 @@ on:
         type: string
         required: false
         default: Release tracking
+      node-version:
+        type: number
+        required: false
+        default: 16
     secrets:
       gh_token:
         required: true
@@ -33,7 +37,7 @@ jobs:
       - name: Set up Node
         uses: actions/setup-node@v2
         with:
-          node-version: 16
+          node-version: ${{ inputs.node-version }}
 
       - name: Install dependencies
         run: ${{ inputs.install }}

--- a/.github/workflows/release_canary.yml
+++ b/.github/workflows/release_canary.yml
@@ -7,6 +7,10 @@ on:
         type: string
         required: false
         default: npm ci
+      node-version:
+        type: number
+        required: false
+        default: 16
     secrets:
       gh_token: 
         required: true
@@ -27,7 +31,7 @@ jobs:
       - name: Set up Node
         uses: actions/setup-node@v2
         with:
-          node-version: 16
+          node-version: ${{ inputs.node-version }}
 
       - name: Install dependencies
         run: ${{ inputs.install }}

--- a/.github/workflows/release_candidate.yml
+++ b/.github/workflows/release_candidate.yml
@@ -11,6 +11,10 @@ on:
         type: string
         required: false
         default: next
+      node-version:
+        type: number
+        required: false
+        default: 16
     secrets:
       gh_token: 
         required: true
@@ -31,7 +35,7 @@ jobs:
       - name: Set up Node
         uses: actions/setup-node@v2
         with:
-          node-version: 16
+          node-version: ${{ inputs.node-version }}
 
       - name: Install dependencies
         run: ${{ inputs.install }}


### PR DESCRIPTION
### Problem Statement
There was no way to specify which node version you wanted these workflows to run with. This makes it difficult to use them on any project other than a node 16 project

### Solution
Adding this as an optional input allows users to specify their desired node version