### PR TITLE
Added Registry Input

### DIFF
--- a/.github/workflows/release_canary.yml
+++ b/.github/workflows/release_canary.yml
@@ -54,6 +54,7 @@ jobs:
             $registry:_authToken=$NPM_TOKEN
           EOF
         env:
+          useGPR: ${{ inputs.useGPR }}
           NPM_TOKEN: ${{ secrets.npm_token }}
 
       - name: Publish canary release

--- a/.github/workflows/release_canary.yml
+++ b/.github/workflows/release_canary.yml
@@ -11,6 +11,10 @@ on:
         type: number
         required: false
         default: 16
+      registry:
+        type: string
+        required: false
+        default: registry.npmjs.org
     secrets:
       gh_token: 
         required: true
@@ -42,7 +46,7 @@ jobs:
       - name: Create .npmrc
         run: |
           cat << EOF > "$HOME/.npmrc"
-            //registry.npmjs.org/:_authToken=$NPM_TOKEN
+            //${{ inputs.registry }}/:_authToken=$NPM_TOKEN
           EOF
         env:
           NPM_TOKEN: ${{ secrets.npm_token }}

--- a/.github/workflows/release_canary.yml
+++ b/.github/workflows/release_canary.yml
@@ -11,10 +11,10 @@ on:
         type: number
         required: false
         default: 16
-      registry:
-        type: string
+      useGPR:
+        type: boolean
         required: false
-        default: registry.npmjs.org
+        default: false
     secrets:
       gh_token: 
         required: true
@@ -45,8 +45,13 @@ jobs:
 
       - name: Create .npmrc
         run: |
+          if [ "$useGPR" = "true" ]; then
+            registry="//npm.pkg.github.com/"
+          else
+            registry="//registry.npmjs.org/"
+          fi
           cat << EOF > "$HOME/.npmrc"
-            //${{ inputs.registry }}/:_authToken=$NPM_TOKEN
+            $registry:_authToken=$NPM_TOKEN
           EOF
         env:
           NPM_TOKEN: ${{ secrets.npm_token }}

--- a/.github/workflows/release_canary.yml
+++ b/.github/workflows/release_canary.yml
@@ -7,11 +7,11 @@ on:
         type: string
         required: false
         default: npm ci
-      node-version:
+      node_version:
         type: number
         required: false
         default: 16
-      useGPR:
+      use_gpr:
         type: boolean
         required: false
         default: false
@@ -35,7 +35,7 @@ jobs:
       - name: Set up Node
         uses: actions/setup-node@v2
         with:
-          node-version: ${{ inputs.node-version }}
+          node_version: ${{ inputs.node_version }}
 
       - name: Install dependencies
         run: ${{ inputs.install }}
@@ -45,7 +45,7 @@ jobs:
 
       - name: Create .npmrc
         run: |
-          if [ "$useGPR" = "true" ]; then
+          if [ "$use_gpr" = "true" ]; then
             registry="//npm.pkg.github.com/"
           else
             registry="//registry.npmjs.org/"
@@ -54,7 +54,7 @@ jobs:
             $registry:_authToken=$NPM_TOKEN
           EOF
         env:
-          useGPR: ${{ inputs.useGPR }}
+          use_gpr: ${{ inputs.use_gpr }}
           NPM_TOKEN: ${{ secrets.npm_token }}
 
       - name: Publish canary release

--- a/.github/workflows/release_candidate.yml
+++ b/.github/workflows/release_candidate.yml
@@ -15,6 +15,10 @@ on:
         type: number
         required: false
         default: 16
+      registry:
+        type: string
+        required: false
+        default: registry.npmjs.org
     secrets:
       gh_token: 
         required: true
@@ -46,7 +50,7 @@ jobs:
       - name: Create .npmrc
         run: |
           cat << EOF > "$HOME/.npmrc"
-            //registry.npmjs.org/:_authToken=$NPM_TOKEN
+            //${{ inputs.registry }}/:_authToken=$NPM_TOKEN
           EOF
         env:
           NPM_TOKEN: ${{ secrets.npm_token }}

--- a/.github/workflows/release_candidate.yml
+++ b/.github/workflows/release_candidate.yml
@@ -11,11 +11,11 @@ on:
         type: string
         required: false
         default: next
-      node-version:
+      node_version:
         type: number
         required: false
         default: 16
-      useGPR:
+      use_gpr:
         type: boolean
         required: false
         default: false
@@ -39,7 +39,7 @@ jobs:
       - name: Set up Node
         uses: actions/setup-node@v2
         with:
-          node-version: ${{ inputs.node-version }}
+          node_version: ${{ inputs.node_version }}
 
       - name: Install dependencies
         run: ${{ inputs.install }}
@@ -49,7 +49,7 @@ jobs:
 
       - name: Create .npmrc
         run: |
-          if [ "$useGPR" = "true" ]; then
+          if [ "$use_gpr" = "true" ]; then
             registry="//npm.pkg.github.com/"
           else
             registry="//registry.npmjs.org/"
@@ -58,6 +58,7 @@ jobs:
             $registry:_authToken=$NPM_TOKEN
           EOF
         env:
+          use_gpr: ${{ inputs.use_gpr }}
           NPM_TOKEN: ${{ secrets.npm_token }}
 
       - name: Publish release candidate

--- a/.github/workflows/release_candidate.yml
+++ b/.github/workflows/release_candidate.yml
@@ -15,10 +15,10 @@ on:
         type: number
         required: false
         default: 16
-      registry:
-        type: string
+      useGPR:
+        type: boolean
         required: false
-        default: registry.npmjs.org
+        default: false
     secrets:
       gh_token: 
         required: true
@@ -49,8 +49,13 @@ jobs:
 
       - name: Create .npmrc
         run: |
+          if [ "$useGPR" = "true" ]; then
+            registry="//npm.pkg.github.com/"
+          else
+            registry="//registry.npmjs.org/"
+          fi
           cat << EOF > "$HOME/.npmrc"
-            //${{ inputs.registry }}/:_authToken=$NPM_TOKEN
+            $registry:_authToken=$NPM_TOKEN
           EOF
         env:
           NPM_TOKEN: ${{ secrets.npm_token }}


### PR DESCRIPTION
### Problem Statement
I am working on a project that needs to use this release workflow but it uses the GitHub Package Registry rather than the NPM registry.

### Solution
Adding a registry input allows the user to reuse this workflow because any registry URL can be provided. It also doesn't affect current workflows because there is a provided default and the input is not required.