### PR TITLE
Explicitly install @changesets/cli as it's required for the `changesets/action` action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,6 +56,10 @@ jobs:
           use_gpr: ${{ inputs.use_gpr }}
           NPM_TOKEN: ${{ secrets.npm_token }}
 
+      # `changesets/action` depends on @changesets/cli being installed
+      # and we cannot add it as dependency because it conflicts with `primer-changesets-cli`
+      - run: npm install @changesets/cli@2.26.1
+
       - name: Create release pull request or publish to npm
         id: changesets
         # Uses SHA for security hardening


### PR DESCRIPTION
We cannot add `@changesets/cli` as dependency because it conflicts with `primer-changesets-cli`

This is required for https://github.com/primer/react/pull/3352