### PR TITLE
Add `--no-save` flag to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,7 +58,7 @@ jobs:
 
       # `changesets/action` depends on @changesets/cli being installed
       # and we cannot add it as dependency because it conflicts with `primer-changesets-cli`
-      - run: npm install @changesets/cli@2.26.1
+      - run: npm install @changesets/cli@2.26.1 --no-save
 
       - name: Create release pull request or publish to npm
         id: changesets


### PR DESCRIPTION
When running the release workflow, the `@changesets/cli` package will be added to the `npm` package's `package.json` file. This PR updates the command to use the `--no-save` option so that it is not included in the package's `package.json`.