### PR TITLE
Fix failing preview deployments

### DIFF
--- a/.github/workflows/deploy_preview.yml
+++ b/.github/workflows/deploy_preview.yml
@@ -67,6 +67,7 @@ jobs:
         uses: actions/upload-artifact@v2
         with:
           path: ${{ inputs.output_dir }}
+          name: preview
 
   deploy:
     name: Deploy
@@ -80,6 +81,7 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v3
+        uses: actions/deploy-pages@v2
         with:
           preview: true
+          artifact_name: preview

--- a/.github/workflows/deploy_preview.yml
+++ b/.github/workflows/deploy_preview.yml
@@ -27,6 +27,11 @@ on:
       gh_token:
         required: false
 
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
 jobs:
   build:
     name: Build
@@ -70,10 +75,6 @@ jobs:
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
-    permissions:
-      contents: read
-      pages: write
-      id-token: write
     outputs:
       deployment_url: ${{ steps.deployment.outputs.page_url }}
     steps:

--- a/.github/workflows/deploy_preview.yml
+++ b/.github/workflows/deploy_preview.yml
@@ -58,14 +58,10 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.gh_token }}
 
-      - name: Archive build output
-        run: "tar --dereference --directory ${{ inputs.output_dir }} -cvf artifact.tar ."
-
       - name: Upload artifact
-        uses: actions/upload-artifact@main
+        uses: actions/upload-artifact@v2
         with:
-          name: github-pages
-          path: artifact.tar
+          path: ${{ inputs.output_dir }}
 
   deploy:
     name: Deploy

--- a/.github/workflows/deploy_preview.yml
+++ b/.github/workflows/deploy_preview.yml
@@ -67,7 +67,6 @@ jobs:
         uses: actions/upload-artifact@v2
         with:
           path: ${{ inputs.output_dir }}
-          name: preview
 
   deploy:
     name: Deploy
@@ -84,4 +83,3 @@ jobs:
         uses: actions/deploy-pages@v2
         with:
           preview: true
-          artifact_name: preview

--- a/.github/workflows/deploy_preview.yml
+++ b/.github/workflows/deploy_preview.yml
@@ -80,6 +80,6 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v2
+        uses: actions/deploy-pages@13b55b33dd8996121833dbc1db458c793a334630
         with:
           preview: true


### PR DESCRIPTION
🚧 WIP

Preview deployments are failing across all repo's that use the deploy_preview.yml workflow.

PR fixes it by removing custom artifact location, which isn't needed anymore.