### PR TITLE
Create release tracking workflow

### DIFF
--- a/.github/workflows/release_tracking.yml
+++ b/.github/workflows/release_tracking.yml
@@ -26,8 +26,8 @@ jobs:
         with:
           api-key: ${{ secrets.datadog_api_key }}
           events: |
-            - title: "Primer Release Tracking PR"
-              text: "%%% \nPrimer release tracking [pull request ${{ github.event.action }}](${{ github.event.pull_request.html_url }})\n %%%"
+            - title: "Release Tracking PR ${{ steps.release-info.outputs.event }} – ${{ github.repository }}"
+              text: "%%% \nPrimer release tracking [pull request ${{ steps.release-info.outputs.event }}](${{ github.event.pull_request.html_url }})\n %%%"
               priority: "normal"
               alert_type: "${{ steps.release-info.outputs.alert_type }}"
               source_type_name: "GITHUB"
@@ -61,8 +61,8 @@ jobs:
         with:
           api-key: ${{ secrets.datadog_api_key }}
           events: |
-            - title: "Primer Release Published"
-              text: "%%% \nPublished release [${{ github.repository }}@${{ github.event.release.tag_name }}](${{ github.event.release.html_url }})\n %%%"
+            - title: "Release Published – ${{ github.repository }}"
+              text: "%%% \nPublished ${{ steps.release-info.outputs.bump }} release [${{ github.repository }}@${{ github.event.release.tag_name }}](${{ github.event.release.html_url }})\n %%%"
               priority: "normal"
               alert_type: "success"
               source_type_name: "GITHUB"

--- a/.github/workflows/release_tracking.yml
+++ b/.github/workflows/release_tracking.yml
@@ -36,7 +36,7 @@ jobs:
                 - "source:primer"
                 - "task:release"
                 - "event:tracking_${{ steps.release-info.outputs.event }}"
-                - "repo:${{ github.repository }}"
+                - "library:${{ github.repository }}"
 
   release-published:
     if: github.event_name == 'release' && github.event.action == 'published'
@@ -46,6 +46,7 @@ jobs:
         id: release-info
         with:
           script: |
+            console.log(context)
             const body = context.payload.release.body
             const published_at = context.payload.release.published_at
             let bump = ''
@@ -72,4 +73,4 @@ jobs:
                 - "task:release"
                 - "event:published"
                 - "version:${{ steps.release-info.outputs.bump }}"
-                - "repo:${{ github.repository }}"
+                - "library:${{ github.repository }}"

--- a/.github/workflows/release_tracking.yml
+++ b/.github/workflows/release_tracking.yml
@@ -49,6 +49,7 @@ jobs:
             console.log(context)
             const body = context.payload.release.body
             const published_at = context.payload.release.published_at
+            const version = context.payload.release.tag_name.replace(/^[^0-9]+/, '')
             let bump = ''
             if (body.includes('### Major Changes\r\n')) {
               bump = 'major'
@@ -58,13 +59,14 @@ jobs:
               bump = 'patch'
             }
             core.setOutput('bump', bump)
+            core.setOutput('version', version)
       - name: Datadog log event
         uses: masci/datadog@v1
         with:
           api-key: ${{ secrets.datadog_api_key }}
           events: |
-            - title: "Release Published – ${{ github.repository }}@${{ github.event.release.tag_name }}"
-              text: "%%% \nPublished ${{ steps.release-info.outputs.bump }} release [${{ github.repository }}@${{ github.event.release.tag_name }}](${{ github.event.release.html_url }})\n %%%"
+            - title: "Release Published – ${{ github.repository }}@${{ steps.release-info.outputs.version }}"
+              text: "%%% \nPublished ${{ steps.release-info.outputs.bump }} release [${{ github.repository }}@${{ steps.release-info.outputs.version }}](${{ github.event.release.html_url }})\n %%%"
               priority: "normal"
               alert_type: "success"
               source_type_name: "GITHUB"

--- a/.github/workflows/release_tracking.yml
+++ b/.github/workflows/release_tracking.yml
@@ -61,7 +61,7 @@ jobs:
         with:
           api-key: ${{ secrets.datadog_api_key }}
           events: |
-            - title: "Release Published – ${{ github.repository }}"
+            - title: "Release Published – ${{ github.repository }}@${{ github.event.release.tag_name }}"
               text: "%%% \nPublished ${{ steps.release-info.outputs.bump }} release [${{ github.repository }}@${{ github.event.release.tag_name }}](${{ github.event.release.html_url }})\n %%%"
               priority: "normal"
               alert_type: "success"

--- a/.github/workflows/release_tracking.yml
+++ b/.github/workflows/release_tracking.yml
@@ -18,7 +18,7 @@ jobs:
         with:
           script: |
             const event = context.payload.pull_request.merged === true ? 'merged' : context.payload.action
-            const alert_type = event === 'merged' ? 'success' : 'error'
+            const alert_type = event === 'closed' ? 'error' : 'info'
             core.setOutput('event', event)
             core.setOutput('alert_type', alert_type)
       - name: Datadog log event

--- a/.github/workflows/release_tracking.yml
+++ b/.github/workflows/release_tracking.yml
@@ -1,0 +1,72 @@
+name: Release Event Tracking
+# Measure a datadog event every time a release occurs
+
+on:
+  workflow_call:
+    secrets:
+      datadog_api_key:
+        required: true
+
+jobs:
+
+  pull-request:
+    if: github.event_name == 'pull_request' && github.event.pull_request.head.ref == 'changeset-release/main'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v7
+        id: release-info
+        with:
+          script: |
+            const event = context.payload.pull_request.merged === true ? 'merged' : context.payload.action
+            const alert_type = event === 'merged' ? 'success' : 'error'
+            core.setOutput('event', event)
+            core.setOutput('alert_type', alert_type)
+      - name: Datadog log event
+        uses: masci/datadog@v1
+        with:
+          api-key: ${{ secrets.datadog_api_key }}
+          events: |
+            - title: "Primer Release Tracking PR"
+              text: "%%% \nPrimer release tracking [pull request ${{ github.event.action }}](${{ github.event.pull_request.html_url }})\n %%%"
+              priority: "normal"
+              alert_type: "${{ steps.release-info.outputs.alert_type }}"
+              tags:
+                - "source:primer"
+                - "task:release"
+                - "event:tracking_${{ steps.release-info.outputs.event }}"
+                - "repo:${{ github.repository }}"
+
+  release-published:
+    if: github.event_name == 'release' && github.event.action == 'published'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v7
+        id: release-info
+        with:
+          script: |
+            const body = context.payload.release.body
+            const published_at = context.payload.release.published_at
+            let bump = ''
+            if (body.includes('### Major Changes\r\n')) {
+              bump = 'major'
+            } else if (body.includes('### Minor Changes\r\n')) {
+              bump = 'minor'
+            } else {
+              bump = 'patch'
+            }
+            core.setOutput('bump', bump)
+      - name: Datadog log event
+        uses: masci/datadog@v1
+        with:
+          api-key: ${{ secrets.datadog_api_key }}
+          events: |
+            - title: "Primer Release Published"
+              text: "%%% \nPublished release [${{ github.repository }}@${{ github.event.release.tag_name }}](${{ github.event.release.html_url }})\n %%%"
+              priority: "normal"
+              alert_type: "success"
+              tags:
+                - "source:primer"
+                - "task:release"
+                - "event:published"
+                - "version:${{ steps.release-info.outputs.bump }}"
+                - "repo:${{ github.repository }}"

--- a/.github/workflows/release_tracking.yml
+++ b/.github/workflows/release_tracking.yml
@@ -30,6 +30,7 @@ jobs:
               text: "%%% \nPrimer release tracking [pull request ${{ github.event.action }}](${{ github.event.pull_request.html_url }})\n %%%"
               priority: "normal"
               alert_type: "${{ steps.release-info.outputs.alert_type }}"
+              source_type_name: "GITHUB"
               tags:
                 - "source:primer"
                 - "task:release"
@@ -64,6 +65,7 @@ jobs:
               text: "%%% \nPublished release [${{ github.repository }}@${{ github.event.release.tag_name }}](${{ github.event.release.html_url }})\n %%%"
               priority: "normal"
               alert_type: "success"
+              source_type_name: "GITHUB"
               tags:
                 - "source:primer"
                 - "task:release"

--- a/.github/workflows/release_tracking.yml
+++ b/.github/workflows/release_tracking.yml
@@ -17,6 +17,7 @@ jobs:
         id: release-info
         with:
           script: |
+            console.log(context)
             const event = context.payload.pull_request.merged === true ? 'merged' : context.payload.action
             const alert_type = event === 'closed' ? 'error' : 'info'
             core.setOutput('event', event)

--- a/workflow-templates/release_tracking.properties.json
+++ b/workflow-templates/release_tracking.properties.json
@@ -1,0 +1,4 @@
+{
+  "name": "Release Tracking",
+  "description": "Measure a datadog event every time a release occurs"
+}

--- a/workflow-templates/release_tracking.yml
+++ b/workflow-templates/release_tracking.yml
@@ -1,0 +1,19 @@
+name: Release Event Tracking
+# Measure a datadog event every time a release occurs
+
+on:
+  pull_request:
+    types:
+      - closed
+      - opened
+      - reopened
+
+  release:
+    types: [published]
+
+jobs:
+  release-tracking:
+    name: Release Tracking
+    uses: primer/.github/.github/workflows/release_tracking.yml@main
+    secrets:
+      datadog_api_key: ${{ secrets.DATADOG_API_KEY }}


### PR DESCRIPTION
Part of https://github.com/github/primer/issues/3181

This PR creates event tracking for when changesets release PRs are opened and merged, and when releases occur