### PR TITLE
Update release_conductor.yml

### DIFF
--- a/.github/workflows/release_conductor.yml
+++ b/.github/workflows/release_conductor.yml
@@ -2,7 +2,7 @@ name: Assign Release Conductor
 
 on:
   schedule:
-    - cron: '30 16 * * MON' # Run after schedules have changed for the week
+    - cron: '30 16 * * *' # Run after schedules have changed for the week
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/release_conductor.yml
+++ b/.github/workflows/release_conductor.yml
@@ -2,7 +2,7 @@ name: Assign Release Conductor
 
 on:
   schedule:
-    - cron: '0 0 * * *' # 12:00 AM UTC daily
+    - cron: '30 16 * * MON' # Run after schedules have changed for the week
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
Update the workflow to be in sync with what we do for our release tracking issues over in: https://github.com/primer/react/blob/main/.github/workflows/release-schedule.yml#L9C13-L9C26. This makes it so that the workflow runs daily and should run after our schedules have swapped for the day. Without this, the workflow will have run too soon and so the release conductor will miss a day without having been assigned to the appropriate team.