### PR TITLE
Adding a package_paths input argument for the upload-versions action

### DIFF
--- a/.github/actions/upload-versions/action.yml
+++ b/.github/actions/upload-versions/action.yml
@@ -1,23 +1,27 @@
-name: 'Upload Versions'
-description: 'Upload version information for public packages'
+name: "Upload Versions"
+description: "Upload version information for public packages"
+inputs:
+  package_paths:
+    description: "Glob pattern(s) for package.json files to extract versions from"
+    required: false
+    default: |
+      **/package.json
+      !**/node_modules/**
 runs:
-  using: 'composite'
+  using: "composite"
   steps:
     - name: Set up Node.js
       uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
       with:
-        node-version: 22
-    - name: Install glob package
-      shell: bash
-      run: npm install glob --no-package-lock
+        node-version: 24
     - name: Write workspace versions as JSON file
       uses: actions/github-script@a3e7071a34d7e1f219a8a4de9a5e0a34d1ee1293
       with:
         script: |
           const fs = require('node:fs');
-          const {globSync} = require('glob')
 
-          const packageJsonPaths = globSync('**/package.json', { ignore: ['**/node_modules/**'] })
+          const globber = await glob.create(`${{ inputs.package_paths }}`)
+          const packageJsonPaths = await globber.glob()
           const output = {
             packages: [],
           };


### PR DESCRIPTION
# Summary
This PR adds a package_paths input parameter to the upload-versions action, allowing users to customize which package.json files are scanned for version information.

# Changes
* Added package_paths input parameter: Optional parameter that accepts glob pattern(s) for locating package.json files

  * Defaults to **/package.json with !**/node_modules/** exclusion to maintain backward compatibility
  * Allows customization for monorepos or specific directory structures
* Updated glob implementation: Switched from the npm glob package to GitHub Actions' built-in glob utility

  * Removes dependency on external npm package installation
  * Uses @actions/glob which is already available in github-script context
* Node.js version bump: Updated from Node.js 22 to 24

* Code formatting: Standardized quote style to double quotes throughout the action

# Testing

I test ran this in a PR on primer/react https://github.com/primer/react/actions/runs/19148429234?pr=7156