### PR TITLE
Create an action that reports back all published versions

### DIFF
--- a/.github/actions/report-versions/action.yml
+++ b/.github/actions/report-versions/action.yml
@@ -15,7 +15,7 @@ runs:
       with:
         node-version: 24
     - name: Create deployments for the versions
-      uses: actions/github-script@a3e7071a34d7e1f219a8a4de9a5e0a34d1ee1293
+      uses: actions/github-script@v8
       with:
         script: |
           const fs = require('node:fs');

--- a/.github/actions/report-versions/action.yml
+++ b/.github/actions/report-versions/action.yml
@@ -30,7 +30,7 @@ runs:
               continue;
             }
 
-            github.rest.repos.createCommitStatus({
+            await github.rest.repos.createCommitStatus({
               owner: context.repo.owner,
               repo: context.repo.repo,
               sha: context.sha,

--- a/.github/actions/report-versions/action.yml
+++ b/.github/actions/report-versions/action.yml
@@ -1,0 +1,42 @@
+name: "Report Versions"
+description: "Report the versions back to the pull request."
+inputs:
+  package_paths:
+    description: "Glob pattern(s) for package.json files to extract versions from"
+    required: false
+    default: |
+      **/package.json
+      !**/node_modules/**
+runs:
+  using: "composite"
+  steps:
+    - name: Set up Node.js
+      uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
+      with:
+        node-version: 24
+    - name: Create deployments for the versions
+      uses: actions/github-script@a3e7071a34d7e1f219a8a4de9a5e0a34d1ee1293
+      with:
+        script: |
+          const fs = require('node:fs');
+
+          const globber = await glob.create(`${{ inputs.package_paths }}`)
+          const packageJsonPaths = await globber.glob()
+
+          for (const packageJsonPath of packageJsonPaths) {
+            const contents = fs.readFileSync(packageJsonPath, 'utf8');
+            const packageJson = JSON.parse(contents);
+            if (packageJson.private) {
+              continue;
+            }
+
+            github.rest.repos.createCommitStatus({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              sha: context.sha,
+              state: 'success',
+              context: `Published ${packageJson.name}`,
+              description: packageJson.version,
+              target_url: `https://unpkg.com/${packageJson.name}@${packageJson.version}/`
+            })
+          }


### PR DESCRIPTION
## Summary

This PR introduces a new `report-versions` composite action that automatically creates commit statuses for all published packages in a repository, providing visibility into which package versions are associated with each commit.

## Changes

**New Action: `report-versions`**
- Creates GitHub commit statuses for each public package found in the repository
- Each status includes the package name and version
- Links directly to the published version on unpkg.com for easy verification

## Features

- **Customizable package discovery**: Accepts a `package_paths` input parameter for flexible glob patterns
  - Defaults to `**/package.json` with `!**/node_modules/**` exclusion
  - Allows customization for monorepos or specific directory structures

- **Smart filtering**: Automatically skips private packages (those marked with `"private": true`)

- **Commit status integration**: Creates success statuses on commits with context like `Published @primer/react` and description showing the version number

- **Direct links**: Each status includes a target URL pointing to `https://unpkg.com/{package}@{version}/` for instant access to the published version

## Testing

I ran this as a test on https://github.com/primer/react/pull/7156

<img width="1898" height="340" alt="CleanShot 2025-11-06 at 13 33 48@2x" src="https://github.com/user-attachments/assets/2170ccf2-fb38-4995-97eb-0712093f1edf" />
